### PR TITLE
Corrected typo in --status-focus-info-bg

### DIFF
--- a/catppuccin-theme-variant.css
+++ b/catppuccin-theme-variant.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-{{THEME}}-surface1);
 	--status-focus-bg: var(--ctp-{{THEME}}-surface1);
 	--status-info-bg: var(--ctp-{{THEME}}-surface2);
-	--status-focus-ingo-bg: var(--ctp-{{THEME}}-surface2);
+	--status-focus-info-bg: var(--ctp-{{THEME}}-surface2);
 
 	--button-fg: var(--ctp-{{THEME}}-crust);
 

--- a/dist/catppuccin-frappe-blue.css
+++ b/dist/catppuccin-frappe-blue.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-flamingo.css
+++ b/dist/catppuccin-frappe-flamingo.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-green.css
+++ b/dist/catppuccin-frappe-green.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-lavender.css
+++ b/dist/catppuccin-frappe-lavender.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-maroon.css
+++ b/dist/catppuccin-frappe-maroon.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-mauve.css
+++ b/dist/catppuccin-frappe-mauve.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-peach.css
+++ b/dist/catppuccin-frappe-peach.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-pink.css
+++ b/dist/catppuccin-frappe-pink.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-red.css
+++ b/dist/catppuccin-frappe-red.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-rosewater.css
+++ b/dist/catppuccin-frappe-rosewater.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-sapphire.css
+++ b/dist/catppuccin-frappe-sapphire.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-sky.css
+++ b/dist/catppuccin-frappe-sky.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-teal.css
+++ b/dist/catppuccin-frappe-teal.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-frappe-yellow.css
+++ b/dist/catppuccin-frappe-yellow.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-frappe-surface1);
 	--status-focus-bg: var(--ctp-frappe-surface1);
 	--status-info-bg: var(--ctp-frappe-surface2);
-	--status-focus-ingo-bg: var(--ctp-frappe-surface2);
+	--status-focus-info-bg: var(--ctp-frappe-surface2);
 
 	--button-fg: var(--ctp-frappe-crust);
 

--- a/dist/catppuccin-latte-blue.css
+++ b/dist/catppuccin-latte-blue.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-flamingo.css
+++ b/dist/catppuccin-latte-flamingo.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-green.css
+++ b/dist/catppuccin-latte-green.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-lavender.css
+++ b/dist/catppuccin-latte-lavender.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-maroon.css
+++ b/dist/catppuccin-latte-maroon.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-mauve.css
+++ b/dist/catppuccin-latte-mauve.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-peach.css
+++ b/dist/catppuccin-latte-peach.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-pink.css
+++ b/dist/catppuccin-latte-pink.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-red.css
+++ b/dist/catppuccin-latte-red.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-rosewater.css
+++ b/dist/catppuccin-latte-rosewater.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-sapphire.css
+++ b/dist/catppuccin-latte-sapphire.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-sky.css
+++ b/dist/catppuccin-latte-sky.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-teal.css
+++ b/dist/catppuccin-latte-teal.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-latte-yellow.css
+++ b/dist/catppuccin-latte-yellow.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-latte-surface1);
 	--status-focus-bg: var(--ctp-latte-surface1);
 	--status-info-bg: var(--ctp-latte-surface2);
-	--status-focus-ingo-bg: var(--ctp-latte-surface2);
+	--status-focus-info-bg: var(--ctp-latte-surface2);
 
 	--button-fg: var(--ctp-latte-crust);
 

--- a/dist/catppuccin-macchiato-blue.css
+++ b/dist/catppuccin-macchiato-blue.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-flamingo.css
+++ b/dist/catppuccin-macchiato-flamingo.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-green.css
+++ b/dist/catppuccin-macchiato-green.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-lavender.css
+++ b/dist/catppuccin-macchiato-lavender.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-maroon.css
+++ b/dist/catppuccin-macchiato-maroon.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-mauve.css
+++ b/dist/catppuccin-macchiato-mauve.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-peach.css
+++ b/dist/catppuccin-macchiato-peach.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-pink.css
+++ b/dist/catppuccin-macchiato-pink.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-red.css
+++ b/dist/catppuccin-macchiato-red.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-rosewater.css
+++ b/dist/catppuccin-macchiato-rosewater.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-sapphire.css
+++ b/dist/catppuccin-macchiato-sapphire.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-sky.css
+++ b/dist/catppuccin-macchiato-sky.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-teal.css
+++ b/dist/catppuccin-macchiato-teal.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-macchiato-yellow.css
+++ b/dist/catppuccin-macchiato-yellow.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-macchiato-surface1);
 	--status-focus-bg: var(--ctp-macchiato-surface1);
 	--status-info-bg: var(--ctp-macchiato-surface2);
-	--status-focus-ingo-bg: var(--ctp-macchiato-surface2);
+	--status-focus-info-bg: var(--ctp-macchiato-surface2);
 
 	--button-fg: var(--ctp-macchiato-crust);
 

--- a/dist/catppuccin-mocha-blue.css
+++ b/dist/catppuccin-mocha-blue.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-flamingo.css
+++ b/dist/catppuccin-mocha-flamingo.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-green.css
+++ b/dist/catppuccin-mocha-green.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-lavender.css
+++ b/dist/catppuccin-mocha-lavender.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-maroon.css
+++ b/dist/catppuccin-mocha-maroon.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-mauve.css
+++ b/dist/catppuccin-mocha-mauve.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-peach.css
+++ b/dist/catppuccin-mocha-peach.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-pink.css
+++ b/dist/catppuccin-mocha-pink.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-red.css
+++ b/dist/catppuccin-mocha-red.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-rosewater.css
+++ b/dist/catppuccin-mocha-rosewater.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-sapphire.css
+++ b/dist/catppuccin-mocha-sapphire.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-sky.css
+++ b/dist/catppuccin-mocha-sky.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-teal.css
+++ b/dist/catppuccin-mocha-teal.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 

--- a/dist/catppuccin-mocha-yellow.css
+++ b/dist/catppuccin-mocha-yellow.css
@@ -25,7 +25,7 @@
 	--status-bg: var(--ctp-mocha-surface1);
 	--status-focus-bg: var(--ctp-mocha-surface1);
 	--status-info-bg: var(--ctp-mocha-surface2);
-	--status-focus-ingo-bg: var(--ctp-mocha-surface2);
+	--status-focus-info-bg: var(--ctp-mocha-surface2);
 
 	--button-fg: var(--ctp-mocha-crust);
 


### PR DESCRIPTION
Looks like one letter was off in the line 28 for the variable `--status-focus-info-bg`. I checked on my instance, and with the change, my browser now uses the proper theme color for the status bar.